### PR TITLE
Remove tokio-middleware dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
-tokio-middleware = { git = "https://github.com/tokio-rs/tokio-middleware" }
 tokio-timer = "0.1"
 tokio-retry = "0.1"
 tokio-tls = { version = "0.1", features = ["tokio-proto"] }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -19,12 +19,13 @@ use futures::{Async, IntoFuture, Poll};
 use futures::future::{self, Future};
 use futures::unsync::oneshot;
 use tokio_core::reactor::{Handle, Timeout};
-use tokio_middleware::{Log as LogMiddleware, Timeout as TimeoutMiddleware};
 use tokio_service::Service;
 use tokio_timer::Timer;
 
+
 use client::{Broker, BrokerRef, ClientBuilder, ClientConfig, Cluster, InFlightMiddleware,
              KafkaService, Metadata, Metrics};
+use client::middleware::Timeout as TimeoutMiddleware;
 use errors::{Error, ErrorKind, Result};
 use network::{KafkaRequest, KafkaResponse, OffsetAndMetadata, TopicPartition};
 use protocol::{ApiKeys, ApiVersion, CorrelationId, DEFAULT_RESPONSE_MAX_BYTES, ErrorCode,
@@ -284,7 +285,7 @@ pub struct KafkaClient<'a> {
 struct Inner<'a> {
     config: ClientConfig,
     handle: Handle,
-    service: InFlightMiddleware<LogMiddleware<TimeoutMiddleware<KafkaService<'a>>>>,
+    service: InFlightMiddleware<TimeoutMiddleware<KafkaService<'a>>>,
     timer: Rc<Timer>,
     metrics: Option<Rc<Metrics>>,
     state: Rc<RefCell<State>>,
@@ -327,7 +328,7 @@ where
         } else {
             None
         };
-        let service = InFlightMiddleware::new(LogMiddleware::new(TimeoutMiddleware::new(
+        let service = InFlightMiddleware::new(TimeoutMiddleware::new(
             KafkaService::new(
                 handle.clone(),
                 config.max_connection_idle(),
@@ -335,7 +336,7 @@ where
             ),
             config.timer(),
             config.request_timeout(),
-        )));
+        ));
 
         let timer = Rc::new(config.timer());
         let inner = Rc::new(Inner {

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -2,6 +2,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::net::SocketAddr;
+use tokio_timer::{self as timer, Timer};
+use std::time::Duration;
 use std::rc::Rc;
 
 use futures::Future;
@@ -87,5 +89,42 @@ pub trait WithAddr {
 impl<T> WithAddr for (SocketAddr, T) {
     fn addr(&self) -> SocketAddr {
         self.0
+    }
+}
+
+/// Abort requests that are taking too long
+#[derive(Clone)]
+pub struct Timeout<S> {
+    upstream: S,
+    timer: Timer,
+    duration: Duration,
+}
+
+impl<S> Timeout<S> {
+    /// Crate a new `Timeout` with the given `upstream` service.
+    ///
+    /// Requests will be limited to `duration` and aborted once the limit has
+    /// been reached.
+    pub fn new(upstream: S, timer: Timer, duration: Duration) -> Timeout<S> {
+        Timeout {
+            upstream: upstream,
+            duration: duration,
+            timer: timer,
+        }
+    }
+}
+
+impl<S, E> Service for Timeout<S>
+    where S: Service<Error = E>,
+          E: From<timer::TimeoutError<S::Future>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = timer::Timeout<S::Future>;
+
+    fn call(&self, request: Self::Request) -> Self::Future {
+        let resp = self.upstream.call(request);
+        self.timer.timeout(resp, self.duration)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_proto;
 extern crate tokio_service;
-extern crate tokio_middleware;
 extern crate tokio_timer;
 extern crate tokio_retry;
 extern crate tokio_tls;


### PR DESCRIPTION
 tokio-middleware is 1) proof-of-concept 2) deprecated
 LoggingMiddleware is removed altogether (all the println()'s!)
 TimeoutMiddleware moved to client/middleware