### PR TITLE
Fix 'already borrowed' panic in fetcher

### DIFF
--- a/src/consumer/fetcher.rs
+++ b/src/consumer/fetcher.rs
@@ -136,6 +136,7 @@ where
         I: IntoIterator<Item = TopicPartition<'a>>,
     {
         let subscriptions = self.subscriptions.clone();
+        let default_reset_strategy = self.subscriptions.borrow().default_reset_strategy();
 
         let fetch_partitions = partitions
             .into_iter()
@@ -180,7 +181,7 @@ where
                                         if state.position != Some(record.fetch_offset) {
                                             debug!("discarding stale fetch response for {} since its offset {} does not match the expected offset {:?}", tp, record.fetch_offset, state.position);
                                         } else {
-                                            state.need_offset_reset(subscriptions.borrow().default_reset_strategy());
+                                            state.need_offset_reset(default_reset_strategy);
                                         }
                                     }
                                     _ => bail!(ErrorKind::KafkaError(record.error_code)),


### PR DESCRIPTION
```
 thread 'main' panicked at 'already mutably borrowed: BorrowError', libcore/result.rs:945:5
 stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at libstd/sys_common/backtrace.rs:59
             at libstd/panicking.rs:207
   3: std::panicking::default_hook
             at libstd/panicking.rs:223
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:402
   5: std::panicking::begin_panic_fmt
             at libstd/panicking.rs:349
   6: rust_begin_unwind
             at libstd/panicking.rs:325
   7: core::panicking::panic_fmt
             at libcore/panicking.rs:72
   8: core::result::unwrap_failed
             at /checkout/src/libcore/macros.rs:26
   9: <futures::future::chain::Chain<A, B, C>>::poll
             at /checkout/src/libcore/result.rs:809
             at /checkout/src/libcore/cell.rs:692
             at /src/tokio-kafka/src/consumer/fetcher.rs:183
```