### PR TITLE
Compression: snappy compression

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -88,4 +88,18 @@ impl Compression {
             }
         }
     }
+
+    pub fn decompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>> {
+        let mut result = Vec::new();
+        match *self {
+            Compression::None => Ok(None),
+
+            #[cfg(feature = "snappy")]
+            Compression::Snappy => {
+                snappy::uncompress_framed_to(src, &mut result)?;
+                Ok(Some(result))
+            }
+            _ => unimplemented!()
+        }
+    }
 }


### PR DESCRIPTION
I started working on (snappy) compression implementation and it is certainly puzzling.
I'm looking for some advice (documentation on the protocol is scarce).

As far as I understand compression works like this for producing: you create a MessageSet with a single message containing your *actual* MessageSet compressed and having compression flag set to whatever method used.  So in snappy's case this is done with snap::Encoder::new().compress() (quoting docs: `Thie encoder does not use the Snappy frame format and simply compresses the given bytes in one big Snappy block`). Compressed message offsets are set to a sequence of numbers 0, 1, ...

For consuming you receive a Message with compressed flag set, and the MessageSet is in the value field. Here's where it is getting weird! The value starts with 0x82SNAPPY00 and, in fact, uses ["java" framing](https://github.com/optiopay/kafka/blob/master/proto/snappy.go). And it contains a message with offset to some certainly not-around-zero number! 

Does this mean that kafka is actually decompressing and recompressing every message? What's going on?! 
This was my first question.

How to go about integrating compressed messages into parsing would be my second one. Should I decompress at parse time (parse_messageset() function), or later? Any thoughts would be appreciated.