### PR TITLE
Fix api versions

### DIFF
--- a/src/client/cluster.rs
+++ b/src/client/cluster.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use network::TopicPartition;
-use protocol::{ApiKeys, ApiVersion, NodeId, PartitionId, UsableApiVersions};
+use protocol::{ApiKeys, ApiVersion, NodeId, PartitionId, UsableApiVersions, SUPPORTED_API_VERSIONS};
 
 /// A trait for representation of a subset of the nodes, topics, and partitions in the Kafka
 /// cluster.
@@ -83,14 +83,25 @@ impl Broker {
         (&self.host, self.port)
     }
 
-    pub fn api_versions(&self) -> Option<&UsableApiVersions> {
+    fn api_versions(&self) -> Option<&UsableApiVersions> {
         self.api_versions.as_ref()
     }
 
     pub fn api_version(&self, api_key: ApiKeys) -> Option<ApiVersion> {
+        if api_key == ApiKeys::Fetch {
+            return Some(1);
+        }
+        let supported_version: i16 = SUPPORTED_API_VERSIONS
+            .find(api_key).map(|v| v.max_version).unwrap_or(0);
         self.api_versions
             .as_ref()
-            .and_then(|api_versions| api_versions.find(api_key).map(|api_version| api_version.max_version))
+            .and_then(|api_versions|
+                     api_versions.find(api_key)
+                    .map(|api_version| {
+                        debug!("Api Key {:?}, current: {}, supported: {}", api_key, api_version.max_version, supported_version);
+                        ::std::cmp::min(api_version.max_version, supported_version)
+                    })
+            )
     }
 
     pub fn with_api_versions(&self, api_versions: Option<UsableApiVersions>) -> Self {

--- a/src/producer/producer.rs
+++ b/src/producer/producer.rs
@@ -245,9 +245,8 @@ where
 
         let api_version = metadata
             .leader_for(&tp)
-            .and_then(|broker| broker.api_versions())
-            .and_then(|api_versions| api_versions.find(ApiKeys::Produce))
-            .map_or(0, |api_version| api_version.max_version);
+            .and_then(|broker| broker.api_version(ApiKeys::Produce))
+            .unwrap_or(0);
 
         trace!("use API version {} for {:?}", api_version, tp);
 

--- a/src/protocol/api_versions.rs
+++ b/src/protocol/api_versions.rs
@@ -8,6 +8,32 @@ use errors::Result;
 use protocol::{parse_response_header, ApiKeys, ApiVersion, Encodable, ErrorCode, ParseTag, Record, RequestHeader,
                ResponseHeader};
 
+// api versions we support
+lazy_static! {
+    pub static ref SUPPORTED_API_VERSIONS: UsableApiVersions = UsableApiVersions::new(vec![
+        UsableApiVersion {
+            api_key: ApiKeys::Produce,
+            min_version: 0,
+            max_version: 1,
+        },
+        UsableApiVersion {
+            api_key: ApiKeys::Fetch,
+            min_version: 0,
+            max_version: 3,
+        },
+        UsableApiVersion {
+            api_key: ApiKeys::ListOffsets,
+            min_version: 0,
+            max_version: 1,
+        },
+        UsableApiVersion {
+            api_key: ApiKeys::JoinGroup,
+            min_version: 0,
+            max_version: 1,
+        }
+    ]);
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ApiVersionsRequest<'a> {
     pub header: RequestHeader<'a>,

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -207,7 +207,7 @@ named_args!(pub parse_message_set(api_version: ApiVersion)<MessageSet>,
     )
 );
 
-named_args!(parse_message(api_version: ApiVersion)<Message>,
+named_args!(parse_message(_api_version: ApiVersion)<Message>,
     parse_tag!(ParseTag::Message,
         do_parse!(
             offset: be_i64
@@ -223,12 +223,13 @@ named_args!(parse_message(api_version: ApiVersion)<Message>,
 
                 crc == checksum as u32
             }))
-         >> _magic: verify!(be_i8, |v: i8| ApiVersion::from(v) == api_version)
+         >> magic: be_i8
          >> attrs: be_i8
-         >> timestamp: cond!(api_version > 0, be_i64)
+         >> timestamp: cond!(magic > 0, be_i64)
          >> key: parse_opt_bytes
          >> value: parse_opt_bytes
-         >> (Message {
+         >> ({
+            Message {
                 offset,
                 timestamp: timestamp.map(|ts| if (attrs & TIMESTAMP_TYPE_MASK) == 0 {
                     MessageTimestamp::CreateTime(ts)
@@ -238,7 +239,7 @@ named_args!(parse_message(api_version: ApiVersion)<Message>,
                 compression: Compression::from(attrs & COMPRESSION_CODEC_MASK),
                 key,
                 value,
-            })
+            }})
         )
     )
 );

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -26,7 +26,7 @@ mod produce;
 mod schema;
 
 pub use self::api_key::{ApiKey, ApiKeys};
-pub use self::api_versions::{ApiVersionsRequest, ApiVersionsResponse, UsableApiVersion, UsableApiVersions};
+pub use self::api_versions::{ApiVersionsRequest, ApiVersionsResponse, UsableApiVersion, UsableApiVersions, SUPPORTED_API_VERSIONS};
 pub use self::code::{ErrorCode, KafkaCode};
 pub use self::encode::{Encodable, WriteExt, ARRAY_LEN_SIZE, BYTES_LEN_SIZE, OFFSET_SIZE, PARTITION_ID_SIZE,
                        REPLICA_ID_SIZE, STR_LEN_SIZE, TIMESTAMP_SIZE};


### PR DESCRIPTION
1) Currently we choose the highest version supported by broker. This is incorrect, we don't support it in the client for most requests.
2) Using Request api version for parsing Message is also incorrect. It's absolutely possible to receive a Message v0 in response to FetchRequest v1.

This patch allows me to enable `with_api_versions_request()` on Consumer.