### PR TITLE
Better report thunk errors

### DIFF
--- a/src/producer/batch.rs
+++ b/src/producer/batch.rs
@@ -24,6 +24,10 @@ pub struct Thunk {
 }
 
 impl Thunk {
+    pub fn fail(self, err: Error) -> ::std::result::Result<(), Result<RecordMetadata>> {
+        self.sender.send(Err(err))
+    }
+
     pub fn done<K: Hash, V>(
         self,
         interceptors: Option<Rc<RefCell<ProducerInterceptors<K, V>>>>,

--- a/src/producer/producer.rs
+++ b/src/producer/producer.rs
@@ -178,7 +178,7 @@ where
                                     .from_err()
                                     .and_then(move |_| inner.flush_batches(false))
                                     .map(|_| ())
-                                    .map_err(|_| ())
+                                    .map_err(|e| warn!("flush batch error: {:?}", e))
                             };
 
                             inner.clone().client.handle().spawn(future);


### PR DESCRIPTION
When produce_records() times out, producer's send() method reports 'Canceled' which makes it unclear about what's actually going on. 

I do format!() because Error doesn't implement clone(). It's a bit hackish but still better than Canceled.