### PR TITLE
Leave consumer group on timer & unknown heartbeat errors

### DIFF
--- a/src/consumer/coordinator.rs
+++ b/src/consumer/coordinator.rs
@@ -357,9 +357,20 @@ where
 
                                     state.borrow_mut().leaved();
                                 }
-                                _ => warn!("unknown error, {}", err),
+                                Error(ErrorKind::TimeoutError(_), _) => {
+                                    info!("heartbeat timeout error");
+
+                                    state.borrow_mut().leaved();
+                                }
+                                _ => {
+                                    warn!("unknown error, {}", err);
+                                    state.borrow_mut().leaved();
+                                }
                             },
-                            RetryError::TimerError(_) => {},
+                            RetryError::TimerError(_) => {
+                                warn!("timer error");
+                                state.borrow_mut().leaved();
+                            },
                         }
 
                         err.into()


### PR DESCRIPTION
I think it would be best to leave consumer group on any heartbeat error. Without this diff heartbeats just stop on a error and consumer group is left in stable state (while its state is actually unknown) and later commit fails with UnknownMemberId, which is harder to handle. With this diff commit we rejoin the group promptly.